### PR TITLE
[FEAT] 뉴스 검색 기능

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ out/
 
 ### Project ###
 src/main/resources/application-secret.yml
+src/main/generated

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
 	//spring ai (OpenAI)
-	implementation 'org.springframework.ai:spring-ai-starter-model-openai'
+	implementation "org.springframework.ai:spring-ai-starter-model-openai:${springAiVersion}"
+
+	//QueryDsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+	annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
 }
 
 dependencyManagement {
@@ -67,4 +73,19 @@ dependencyManagement {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+//Querydsl 설정
+def generated = 'src/main/generated'
+
+tasks.withType(JavaCompile).configureEach {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+clean {
+	delete file(generated)
 }

--- a/src/main/java/com/company/newseat/global/config/QueryDslConfig.java
+++ b/src/main/java/com/company/newseat/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.company.newseat.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/company/newseat/news/application/NewsService.java
+++ b/src/main/java/com/company/newseat/news/application/NewsService.java
@@ -5,12 +5,16 @@ import com.company.newseat.global.exception.handler.NewsHandler;
 import com.company.newseat.news.domain.News;
 import com.company.newseat.news.dto.request.NewsSummaryRequest;
 import com.company.newseat.news.dto.response.NewsSummaryResponse;
+import com.company.newseat.news.dto.response.SearchNewsResponse;
+import com.company.newseat.news.dto.response.SearchNewsResponseList;
 import com.company.newseat.news.repository.NewsRepository;
 import com.company.newseat.news.util.NewsSummaryPromptProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.ai.openai.OpenAiChatModel;
+
+import java.util.List;
 
 
 @Slf4j
@@ -54,5 +58,22 @@ public class NewsService {
         } catch (Exception e) {
             throw new NewsHandler(ErrorStatus.SUMMARY_GENERATION_FAILED);
         }
+    }
+
+    /**
+     * 키워드로 뉴스 검색
+     */
+    public SearchNewsResponseList searchNews(String keyword, Long lastNewsId, int size) {
+
+        List<News> newsList = newsRepository.searchByKeywordWithCursor(keyword, lastNewsId, size);
+
+        boolean hasMore = newsList.size() > size;
+
+        List<SearchNewsResponse> list = newsList.stream()
+                .limit(size)
+                .map(SearchNewsResponse::of)
+                .toList();
+
+        return SearchNewsResponseList.of(list, hasMore);
     }
 }

--- a/src/main/java/com/company/newseat/news/controller/NewsController.java
+++ b/src/main/java/com/company/newseat/news/controller/NewsController.java
@@ -4,6 +4,7 @@ import com.company.newseat.global.response.ApiResponse;
 import com.company.newseat.news.application.NewsService;
 import com.company.newseat.news.dto.request.NewsSummaryRequest;
 import com.company.newseat.news.dto.response.NewsSummaryResponse;
+import com.company.newseat.news.dto.response.SearchNewsResponseList;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,19 @@ public class NewsController {
             @RequestBody NewsSummaryRequest request) {
 
         NewsSummaryResponse response = newsService.summarizeNewsByContent(request);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "뉴스 검색 (커서 기반 무한 스크롤)",
+            description = "키워드를 기준으로 뉴스 제목과 내용을 검색, lastNewsId를 기준으로 다음 페이지 데이터 조회")
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<SearchNewsResponseList>> searchNews(
+            @RequestParam String keyword,
+            @RequestParam(required = false) Long lastNewsId,
+            @RequestParam(defaultValue = "10") int size) {
+
+        SearchNewsResponseList response = newsService.searchNews(keyword, lastNewsId, size);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }

--- a/src/main/java/com/company/newseat/news/dto/response/SearchNewsResponse.java
+++ b/src/main/java/com/company/newseat/news/dto/response/SearchNewsResponse.java
@@ -1,0 +1,21 @@
+package com.company.newseat.news.dto.response;
+
+import com.company.newseat.news.domain.News;
+
+public record SearchNewsResponse(
+        Long newsId,
+        String imgUrl,
+        String publisher,
+        String title,
+        String content
+) {
+    public static SearchNewsResponse of(News news) {
+        return new SearchNewsResponse(
+                news.getNewsId(),
+                news.getImgUrl(),
+                news.getPublisher(),
+                news.getTitle(),
+                news.getContent()
+        );
+    }
+}

--- a/src/main/java/com/company/newseat/news/dto/response/SearchNewsResponseList.java
+++ b/src/main/java/com/company/newseat/news/dto/response/SearchNewsResponseList.java
@@ -1,0 +1,12 @@
+package com.company.newseat.news.dto.response;
+
+import java.util.List;
+
+public record SearchNewsResponseList(
+        List<SearchNewsResponse> newsResponseList,
+        boolean hasNext
+) {
+    public static SearchNewsResponseList of (List<SearchNewsResponse> newsResponseList, boolean hasNext) {
+        return new SearchNewsResponseList(newsResponseList, hasNext);
+    }
+}

--- a/src/main/java/com/company/newseat/news/repository/NewsRepository.java
+++ b/src/main/java/com/company/newseat/news/repository/NewsRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface NewsRepository extends JpaRepository<News, Long> {
+public interface NewsRepository extends JpaRepository<News, Long>, NewsRepositoryCustom {
 }

--- a/src/main/java/com/company/newseat/news/repository/NewsRepositoryCustom.java
+++ b/src/main/java/com/company/newseat/news/repository/NewsRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.company.newseat.news.repository;
+
+import com.company.newseat.news.domain.News;
+
+import java.util.List;
+
+public interface NewsRepositoryCustom {
+
+    List<News> searchByKeywordWithCursor(String keyword, Long lastNewsId, int size);
+
+}

--- a/src/main/java/com/company/newseat/news/repository/NewsRepositoryImpl.java
+++ b/src/main/java/com/company/newseat/news/repository/NewsRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.company.newseat.news.repository;
+
+import com.company.newseat.news.domain.News;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.company.newseat.news.domain.QNews.news;
+
+@RequiredArgsConstructor
+@Repository
+public class NewsRepositoryImpl implements NewsRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<News> searchByKeywordWithCursor(String keyword, Long lastNewsId, int size) {
+        String lowerKeyword = keyword.toLowerCase();
+
+        var query = queryFactory.selectFrom(news)
+                .where(
+                        Expressions.stringTemplate(
+                                "lower(cast({0} as char))", news.content)
+                                .like("%" + lowerKeyword + "%")
+                                .or(
+                       Expressions.stringTemplate(
+                               "lower(cast({0} as char))", news.title)
+                               .like("%" + lowerKeyword + "%"))
+                )
+                .orderBy(news.newsId.desc())
+                .limit(size + 1);
+
+        if (lastNewsId != null && lastNewsId != 0) {
+            query.where(news.newsId.lt(lastNewsId));
+        }
+
+        return query.fetch();
+    }
+}


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #9


## ✏️ 작업 내용

- 정렬 조건 등 확장성을 위해 QueryDSL 의존성을 사용해서 개발
- 긴 text(content) 타입을 lower(cast(... as char))로 명시적으로 캐스트하여 검색 조건으로 작성
- 커서 기반으로 뉴스 검색 기능 개발


## ✅ 체크리스트
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인


## 💖 리뷰 요청사항
서비스단 로직을 중심으로 보면 좋을 것 같습니다!!