### PR TITLE
[FEAT] 카테고리별 뉴스 목록 조회 기능

### DIFF
--- a/src/main/java/com/company/newseat/bookmark/dto/response/BookmarkSimpleResponse.java
+++ b/src/main/java/com/company/newseat/bookmark/dto/response/BookmarkSimpleResponse.java
@@ -1,10 +1,7 @@
 package com.company.newseat.bookmark.dto.response;
 
 import com.company.newseat.bookmark.domain.Bookmark;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import com.company.newseat.global.util.DateUtil;
 
 public record BookmarkSimpleResponse(
         Long bookmarkId,
@@ -14,7 +11,7 @@ public record BookmarkSimpleResponse(
         String publishedAt
 ) {
     public static BookmarkSimpleResponse of(Bookmark bookmark) {
-        String formattedPublishedAt = formatDate(bookmark.getPublished_at());
+        String formattedPublishedAt = DateUtil.formatDate(bookmark.getPublished_at());
 
         return new BookmarkSimpleResponse(
                 bookmark.getBookmarkId(),
@@ -23,37 +20,5 @@ public record BookmarkSimpleResponse(
                 bookmark.getImgUrl(),
                 formattedPublishedAt
         );
-    }
-
-    private static String formatDate(String rawDate) {
-
-        if (rawDate == null || rawDate.isBlank()) {
-            return "";
-        }
-
-        DateTimeFormatter[] inputFormatters = {
-                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"),
-                DateTimeFormatter.ofPattern("yyyy-MM-dd"),
-                DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss"),
-                DateTimeFormatter.ofPattern("yyyy/MM/dd"),
-                DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss"),
-                DateTimeFormatter.ofPattern("yyyy.MM.dd")
-        };
-
-        DateTimeFormatter outputFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
-
-        for (DateTimeFormatter inputFormatter : inputFormatters) {
-            try {
-                LocalDateTime dateTime = LocalDateTime.parse(rawDate, inputFormatter);
-                return dateTime.format(outputFormatter);
-            } catch (Exception e1) {
-                try {
-                    LocalDate date = LocalDate.parse(rawDate, inputFormatter);
-                    return date.format(outputFormatter);
-                } catch (Exception e2) {
-                }
-            }
-        }
-        return rawDate;
     }
 }

--- a/src/main/java/com/company/newseat/category/domain/Category.java
+++ b/src/main/java/com/company/newseat/category/domain/Category.java
@@ -23,6 +23,9 @@ public class Category {
     @Column(name = "name", length = 50)
     private String name;
 
+    @Column(name = "code", length = 10, unique = true)
+    private String code;
+
     @Column(name = "order_index")
     private int orderIndex;
 
@@ -30,8 +33,9 @@ public class Category {
     private List<News> newsList = new ArrayList<>();
 
     @Builder
-    public Category(String name, int orderIndex) {
+    public Category(String name, String code, int orderIndex) {
         this.name = name;
+        this.code = code;
         this.orderIndex = orderIndex;
     }
 }

--- a/src/main/java/com/company/newseat/category/repository/init/CategoryInitializer.java
+++ b/src/main/java/com/company/newseat/category/repository/init/CategoryInitializer.java
@@ -29,34 +29,42 @@ public class CategoryInitializer implements ApplicationRunner {
 
             Category CATEGORY_POLITICS = Category.builder()
                     .name("정치")
+                    .code("001")
                     .orderIndex(1)
                     .build();
             Category CATEGORY_ECONOMY = Category.builder()
                     .name("경제")
+                    .code("002")
                     .orderIndex(2)
                     .build();
             Category CATEGORY_SOCIETY = Category.builder()
                     .name("사회")
+                    .code("003")
                     .orderIndex(3)
                     .build();
             Category CATEGORY_LIFESTYLE_CULTURE = Category.builder()
                     .name("생활/문화")
+                    .code("004")
                     .orderIndex(4)
                     .build();
             Category CATEGORY_TECH_SCIENCE = Category.builder()
                     .name("IT/과학")
+                    .code("005")
                     .orderIndex(5)
                     .build();
             Category CATEGORY_ENTERTAINMENT = Category.builder()
                     .name("연예")
+                    .code("006")
                     .orderIndex(6)
                     .build();
             Category CATEGORY_SPORTS = Category.builder()
                     .name("스포츠")
+                    .code("007")
                     .orderIndex(7)
                     .build();
             Category CATEGORY_WORLD = Category.builder()
                     .name("세계")
+                    .code("008")
                     .orderIndex(8)
                     .build();
 

--- a/src/main/java/com/company/newseat/global/util/DateUtil.java
+++ b/src/main/java/com/company/newseat/global/util/DateUtil.java
@@ -1,0 +1,44 @@
+package com.company.newseat.global.util;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public class DateUtil {
+
+    private static final DateTimeFormatter[] INPUT_FORMATTERS = {
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"),
+            DateTimeFormatter.ofPattern("yyyy-MM-dd"),
+            DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss"),
+            DateTimeFormatter.ofPattern("yyyy/MM/dd"),
+            DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm:ss"),
+            DateTimeFormatter.ofPattern("yyyy.MM.dd")
+    };
+
+    private static final DateTimeFormatter OUTPUT_FORMATTERS =
+            DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+    private DateUtil() {
+    }
+
+    public static String formatDate(String rawDate) {
+
+        if (rawDate == null || rawDate.isBlank()) {
+            return "";
+        }
+
+        for (DateTimeFormatter inputFormatter : INPUT_FORMATTERS) {
+            try {
+                LocalDateTime dateTime = LocalDateTime.parse(rawDate, inputFormatter);
+                return dateTime.format(OUTPUT_FORMATTERS);
+            } catch (Exception e1) {
+                try {
+                    LocalDate date = LocalDate.parse(rawDate, inputFormatter);
+                    return date.format(OUTPUT_FORMATTERS);
+                } catch (Exception e2) {
+                }
+            }
+        }
+        return rawDate;
+    }
+}

--- a/src/main/java/com/company/newseat/news/application/NewsService.java
+++ b/src/main/java/com/company/newseat/news/application/NewsService.java
@@ -4,9 +4,7 @@ import com.company.newseat.global.exception.code.status.ErrorStatus;
 import com.company.newseat.global.exception.handler.NewsHandler;
 import com.company.newseat.news.domain.News;
 import com.company.newseat.news.dto.request.NewsSummaryRequest;
-import com.company.newseat.news.dto.response.NewsSummaryResponse;
-import com.company.newseat.news.dto.response.SearchNewsResponse;
-import com.company.newseat.news.dto.response.SearchNewsResponseList;
+import com.company.newseat.news.dto.response.*;
 import com.company.newseat.news.repository.NewsRepository;
 import com.company.newseat.news.util.NewsSummaryPromptProvider;
 import lombok.RequiredArgsConstructor;
@@ -67,5 +65,22 @@ public class NewsService {
                 .toList();
 
         return SearchNewsResponseList.of(list, hasMore);
+    }
+
+    /**
+     * 카테고리별 뉴스 목록 조회
+     */
+    public CategoryNewsResponseList getCategoryNews(String categoryName, Long lastNewsId, int size) {
+
+        List<News> newsList = newsRepository.findByCategoryWithCursor(categoryName, lastNewsId, size);
+
+        boolean hasMore = newsList.size() > size;
+
+        List<CategoryNewsResponse> list = newsList.stream()
+                .limit(size)
+                .map(CategoryNewsResponse::of)
+                .toList();
+
+        return CategoryNewsResponseList.of(list, hasMore);
     }
 }

--- a/src/main/java/com/company/newseat/news/application/NewsService.java
+++ b/src/main/java/com/company/newseat/news/application/NewsService.java
@@ -3,7 +3,6 @@ package com.company.newseat.news.application;
 import com.company.newseat.global.exception.code.status.ErrorStatus;
 import com.company.newseat.global.exception.handler.NewsHandler;
 import com.company.newseat.news.domain.News;
-import com.company.newseat.news.dto.request.NewsSummaryRequest;
 import com.company.newseat.news.dto.response.*;
 import com.company.newseat.news.repository.NewsRepository;
 import com.company.newseat.news.util.NewsSummaryPromptProvider;
@@ -70,9 +69,9 @@ public class NewsService {
     /**
      * 카테고리별 뉴스 목록 조회
      */
-    public CategoryNewsResponseList getCategoryNews(String categoryName, Long lastNewsId, int size) {
+    public CategoryNewsResponseList getCategoryNews(String categoryCode, Long lastNewsId, int size) {
 
-        List<News> newsList = newsRepository.findByCategoryWithCursor(categoryName, lastNewsId, size);
+        List<News> newsList = newsRepository.findByCategoryWithCursor(categoryCode, lastNewsId, size);
 
         boolean hasMore = newsList.size() > size;
 

--- a/src/main/java/com/company/newseat/news/controller/NewsController.java
+++ b/src/main/java/com/company/newseat/news/controller/NewsController.java
@@ -46,15 +46,16 @@ public class NewsController {
 
 
     @Operation(summary = "카테고리별 뉴스 조회 기능",
-            description = "카테고리별 뉴스 조회")
-    @GetMapping
-    public ResponseEntity<ApiResponse<CategoryNewsResponseList>> getNewsByCategory(
-            @RequestParam(defaultValue = "경제") String category,
-            @RequestParam(required = false) Long lastNewsId,
-            @RequestParam(defaultValue = "10") int size){
-
-        CategoryNewsResponseList response = newsService.getCategoryNews(category, lastNewsId, size);
-
-        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+            description = "카테고리별 뉴스 조회 <br>" +
+            "카테고리 코드: 정치(001), 경제(002), 사회(003), 생활/문화(004), IT/과학(005), 연예(006), 스포츠(007),세계(008)")
+        @GetMapping
+        public ResponseEntity<ApiResponse<CategoryNewsResponseList>> getNewsByCategory(
+                @RequestParam(defaultValue = "001") String category,
+                @RequestParam(required = false) Long lastNewsId,
+                @RequestParam(defaultValue = "10") int size){
+    
+            CategoryNewsResponseList response = newsService.getCategoryNews(category, lastNewsId, size);
+    
+            return ResponseEntity.ok(ApiResponse.onSuccess(response));
+        }
     }
-}

--- a/src/main/java/com/company/newseat/news/controller/NewsController.java
+++ b/src/main/java/com/company/newseat/news/controller/NewsController.java
@@ -2,6 +2,7 @@ package com.company.newseat.news.controller;
 
 import com.company.newseat.global.response.ApiResponse;
 import com.company.newseat.news.application.NewsService;
+import com.company.newseat.news.dto.response.CategoryNewsResponseList;
 import com.company.newseat.news.dto.response.NewsSummaryResponse;
 import com.company.newseat.news.dto.response.SearchNewsResponseList;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,6 +40,20 @@ public class NewsController {
             @RequestParam(defaultValue = "10") int size) {
 
         SearchNewsResponseList response = newsService.searchNews(keyword, lastNewsId, size);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+
+    @Operation(summary = "카테고리별 뉴스 조회 기능",
+            description = "카테고리별 뉴스 조회")
+    @GetMapping
+    public ResponseEntity<ApiResponse<CategoryNewsResponseList>> getNewsByCategory(
+            @RequestParam(defaultValue = "경제") String category,
+            @RequestParam(required = false) Long lastNewsId,
+            @RequestParam(defaultValue = "10") int size){
+
+        CategoryNewsResponseList response = newsService.getCategoryNews(category, lastNewsId, size);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }

--- a/src/main/java/com/company/newseat/news/dto/response/CategoryNewsResponse.java
+++ b/src/main/java/com/company/newseat/news/dto/response/CategoryNewsResponse.java
@@ -1,0 +1,21 @@
+package com.company.newseat.news.dto.response;
+
+import com.company.newseat.news.domain.News;
+
+public record CategoryNewsResponse(
+        Long newsId,
+        String title,
+        String imgUrl,
+        String publisher,
+        String publishedAt
+) {
+    public static CategoryNewsResponse of(News news) {
+        return new CategoryNewsResponse(
+                news.getNewsId(),
+                news.getTitle(),
+                news.getImgUrl(),
+                news.getPublisher(),
+                news.getPublished_at()
+        );
+    }
+}

--- a/src/main/java/com/company/newseat/news/dto/response/CategoryNewsResponse.java
+++ b/src/main/java/com/company/newseat/news/dto/response/CategoryNewsResponse.java
@@ -1,5 +1,6 @@
 package com.company.newseat.news.dto.response;
 
+import com.company.newseat.global.util.DateUtil;
 import com.company.newseat.news.domain.News;
 
 public record CategoryNewsResponse(
@@ -10,12 +11,14 @@ public record CategoryNewsResponse(
         String publishedAt
 ) {
     public static CategoryNewsResponse of(News news) {
+        String formattedPublishedAt = DateUtil.formatDate(news.getPublished_at());
+
         return new CategoryNewsResponse(
                 news.getNewsId(),
                 news.getTitle(),
                 news.getImgUrl(),
                 news.getPublisher(),
-                news.getPublished_at()
+                formattedPublishedAt
         );
     }
 }

--- a/src/main/java/com/company/newseat/news/dto/response/CategoryNewsResponseList.java
+++ b/src/main/java/com/company/newseat/news/dto/response/CategoryNewsResponseList.java
@@ -1,0 +1,12 @@
+package com.company.newseat.news.dto.response;
+
+import java.util.List;
+
+public record CategoryNewsResponseList(
+        List<CategoryNewsResponse> categoryNewsResponses,
+        boolean hasNext
+) {
+    public static CategoryNewsResponseList of (List<CategoryNewsResponse> categoryNewsResponses, boolean hasNext) {
+        return new CategoryNewsResponseList(categoryNewsResponses, hasNext);
+    }
+}

--- a/src/main/java/com/company/newseat/news/repository/NewsRepositoryCustom.java
+++ b/src/main/java/com/company/newseat/news/repository/NewsRepositoryCustom.java
@@ -7,5 +7,6 @@ import java.util.List;
 public interface NewsRepositoryCustom {
 
     List<News> searchByKeywordWithCursor(String keyword, Long lastNewsId, int size);
+    List<News> findByCategoryWithCursor(String categoryName, Long lastNewsId, int size);
 
 }

--- a/src/main/java/com/company/newseat/news/repository/NewsRepositoryCustom.java
+++ b/src/main/java/com/company/newseat/news/repository/NewsRepositoryCustom.java
@@ -7,6 +7,6 @@ import java.util.List;
 public interface NewsRepositoryCustom {
 
     List<News> searchByKeywordWithCursor(String keyword, Long lastNewsId, int size);
-    List<News> findByCategoryWithCursor(String categoryName, Long lastNewsId, int size);
+    List<News> findByCategoryWithCursor(String categoryCode, Long lastNewsId, int size);
 
 }

--- a/src/main/java/com/company/newseat/news/repository/NewsRepositoryImpl.java
+++ b/src/main/java/com/company/newseat/news/repository/NewsRepositoryImpl.java
@@ -43,11 +43,11 @@ public class NewsRepositoryImpl implements NewsRepositoryCustom {
 
 
     @Override
-    public List<News> findByCategoryWithCursor(String categoryName, Long lastNewsId, int size) {
+    public List<News> findByCategoryWithCursor(String categoryCode, Long lastNewsId, int size) {
         var query = queryFactory
                 .selectFrom(news)
                 .join(news.category, category).fetchJoin()
-                .where(category.name.eq(categoryName))
+                .where(category.code.eq(categoryCode))
                 .orderBy(news.newsId.desc())
                 .limit(size + 1);
 

--- a/src/main/java/com/company/newseat/news/repository/NewsRepositoryImpl.java
+++ b/src/main/java/com/company/newseat/news/repository/NewsRepositoryImpl.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static com.company.newseat.category.domain.QCategory.category;
 import static com.company.newseat.news.domain.QNews.news;
 
 @RequiredArgsConstructor
@@ -30,6 +31,23 @@ public class NewsRepositoryImpl implements NewsRepositoryCustom {
                                "lower(cast({0} as char))", news.title)
                                .like("%" + lowerKeyword + "%"))
                 )
+                .orderBy(news.newsId.desc())
+                .limit(size + 1);
+
+        if (lastNewsId != null && lastNewsId != 0) {
+            query.where(news.newsId.lt(lastNewsId));
+        }
+
+        return query.fetch();
+    }
+
+
+    @Override
+    public List<News> findByCategoryWithCursor(String categoryName, Long lastNewsId, int size) {
+        var query = queryFactory
+                .selectFrom(news)
+                .join(news.category, category).fetchJoin()
+                .where(category.name.eq(categoryName))
                 .orderBy(news.newsId.desc())
                 .limit(size + 1);
 


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #19 


## ✏️ 작업 내용

- 카테고리별 뉴스 목록 조회 기능
  - 카테고리 코드, lastNewsId, size를 받아서 조회
- DTO에서 날짜 형식 변환 로직 공통 Util클래스로 분리


## ✅ 체크리스트
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인


## 💖 리뷰 요청사항
