### PR TITLE
[FEAT] 로그인 회원가입 결과 반환 DTO에 닉네임 필드 추가 및 닉네임 조회 기능

### DIFF
--- a/src/main/java/com/company/newseat/auth/dto/response/LoginResponse.java
+++ b/src/main/java/com/company/newseat/auth/dto/response/LoginResponse.java
@@ -8,12 +8,14 @@ import lombok.Builder;
 @Builder
 public record LoginResponse(
         Role role,
+        String nickname,
         String accessToken,
         String refreshToken
 ) {
     public static LoginResponse of(Tokens token, User user) {
         return LoginResponse.builder()
                 .role(user.getRole())
+                .nickname(user.getNickname())
                 .accessToken(token.accessToken())
                 .refreshToken(token.refreshToken())
                 .build();

--- a/src/main/java/com/company/newseat/auth/dto/response/SignUpResponse.java
+++ b/src/main/java/com/company/newseat/auth/dto/response/SignUpResponse.java
@@ -5,11 +5,13 @@ import lombok.Builder;
 
 @Builder
 public record SignUpResponse(
-        Long userId
+        Long userId,
+        String nickname
 ) {
     public static SignUpResponse of(User user) {
         return SignUpResponse.builder()
                 .userId(user.getUserId())
+                .nickname(user.getNickname())
                 .build();
     }
 }

--- a/src/main/java/com/company/newseat/user/application/UserService.java
+++ b/src/main/java/com/company/newseat/user/application/UserService.java
@@ -9,6 +9,7 @@ import com.company.newseat.user.dto.response.NewsModeResponse;
 import com.company.newseat.user.domain.CategoryPreference;
 import com.company.newseat.user.domain.User;
 import com.company.newseat.user.dto.response.MypageProfileResponse;
+import com.company.newseat.user.dto.response.UserSimpleInfoResponse;
 import com.company.newseat.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -101,5 +102,16 @@ public class UserService {
         userRepository.save(user);
 
         return NewsModeResponse.of(isDetoxMode);
+    }
+
+    /**
+     * 전역에서 사용하는 닉네임 조회용 api
+     */
+    public UserSimpleInfoResponse getMyInfo(Long userId) {
+        String nickname = userRepository.findNicknameById(userId);
+        if (nickname == null) {
+            throw new UserHandler(ErrorStatus.USER_NOT_FOUND);
+        }
+        return UserSimpleInfoResponse.of(nickname);
     }
 }

--- a/src/main/java/com/company/newseat/user/dto/response/UserSimpleInfoResponse.java
+++ b/src/main/java/com/company/newseat/user/dto/response/UserSimpleInfoResponse.java
@@ -1,0 +1,9 @@
+package com.company.newseat.user.dto.response;
+
+public record UserSimpleInfoResponse (
+        String nickname
+) {
+    public static UserSimpleInfoResponse of(String nickname) {
+        return new UserSimpleInfoResponse(nickname);
+    }
+}

--- a/src/main/java/com/company/newseat/user/presentation/UserController.java
+++ b/src/main/java/com/company/newseat/user/presentation/UserController.java
@@ -7,6 +7,7 @@ import com.company.newseat.user.application.UserService;
 import com.company.newseat.user.dto.request.UpdateCategoryRequest;
 import com.company.newseat.user.dto.request.UpdateNicknameRequest;
 import com.company.newseat.user.dto.response.MypageProfileResponse;
+import com.company.newseat.user.dto.response.UserSimpleInfoResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -66,6 +67,16 @@ public class UserController {
             @RequestBody @Valid NewsModeRequest request){
 
         NewsModeResponse response = userService.updateDetoxMode(userId, request.isDetoxMode());
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "내 정보 조회 (전역에서 사용)", description = "현재 로그인한 유저의 기본정보(닉네임) 조회")
+    @PutMapping("/me")
+    public ResponseEntity<ApiResponse<UserSimpleInfoResponse>> getMyInfo(
+            @AuthenticationPrincipal Long userId){
+
+        UserSimpleInfoResponse response = userService.getMyInfo(userId);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }

--- a/src/main/java/com/company/newseat/user/repository/UserRepository.java
+++ b/src/main/java/com/company/newseat/user/repository/UserRepository.java
@@ -20,4 +20,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "JOIN FETCH p.category " +
             "WHERE u.userId = :userId")
     Optional<User> findByIdWithPreferencesAndCategory(@Param("userId") Long userId);
+
+    @Query("select u.nickname from User u where u.userId = :userId")
+    String findNicknameById(@Param("userId") Long userId);
 }


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #35 


## ✏️ 작업 내용

- 로그인, 회원가입 결과 response dto에 닉네임 필드 추가
- 닉네임 조회 기능 개발


## ✅ 체크리스트
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인

