### PR TITLE
[FEAT] 비밀번호 수정 기능

### DIFF
--- a/src/main/java/com/company/newseat/auth/application/AuthService.java
+++ b/src/main/java/com/company/newseat/auth/application/AuthService.java
@@ -1,13 +1,10 @@
 package com.company.newseat.auth.application;
 
-import com.company.newseat.auth.dto.request.SendEmailCodeRequest;
-import com.company.newseat.auth.dto.request.VerifyEmailCodeRequest;
+import com.company.newseat.auth.dto.request.*;
 import com.company.newseat.auth.dto.response.*;
 import com.company.newseat.auth.util.TokenProvider;
 import com.company.newseat.auth.dto.jwt.JwtUserDetails;
 import com.company.newseat.auth.dto.jwt.Tokens;
-import com.company.newseat.auth.dto.request.LoginRequest;
-import com.company.newseat.auth.dto.request.SignUpRequest;
 import com.company.newseat.category.domain.Category;
 import com.company.newseat.category.repository.CategoryRepository;
 import com.company.newseat.email.application.MailService;
@@ -177,5 +174,19 @@ public class AuthService {
 
         emailAuth.setIsChecked(true);
         return true;
+    }
+
+    /**
+     * 로그인한 사용자의 비밀번호 변경
+     */
+    public void changePassword(Long userId, ResetPasswordRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        if (!request.password().equals(request.confirmPassword()))
+            throw new AuthHandler(ErrorStatus.PASSWORD_NOT_CORRECT);
+
+        user.changePassword(passwordEncoder.encode(request.password()));
+        userRepository.save(user);
     }
 }

--- a/src/main/java/com/company/newseat/auth/application/AuthService.java
+++ b/src/main/java/com/company/newseat/auth/application/AuthService.java
@@ -179,8 +179,42 @@ public class AuthService {
     /**
      * 로그인한 사용자의 비밀번호 변경
      */
-    public void changePassword(Long userId, ResetPasswordRequest request) {
+    @Transactional
+    public void changePassword(Long userId, ChangePasswordRequest request) {
         User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        if (!request.password().equals(request.confirmPassword()))
+            throw new AuthHandler(ErrorStatus.PASSWORD_NOT_CORRECT);
+
+        user.changePassword(passwordEncoder.encode(request.password()));
+        userRepository.save(user);
+    }
+
+    /**
+     * 비밀번호 찾기용 이메일 인증 확인
+     */
+    @Transactional
+    public PasswordResetVerifyResponse verifyPasswordReset(PasswordResetVerifyRequest request){
+
+        EmailAuth emailAuth = emailAuthRepository.findById(request.emailAuthId())
+                .orElseThrow(() -> new AuthHandler(ErrorStatus.EMAIL_AUTH_NOT_FOUND));
+
+        if (!emailAuthRepository.existsByEmailAuthIdAndPurposeAndIsChecked(request.emailAuthId(), Purpose.FIND_PW, BooleanType.T))
+            throw new AuthHandler(ErrorStatus.EMAIL_NOT_VERIFIED);
+
+        User user = userRepository.findByEmail(emailAuth.getEmail())
+                .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
+
+        return PasswordResetVerifyResponse.of(user.getUserId());
+    }
+
+    /**
+     * 로그인하지 않은 사용자의 비밀번호 재설정
+     */
+    @Transactional
+    public void resetPassword(ResetPasswordRequest request) {
+        User user = userRepository.findById(request.userId())
                 .orElseThrow(() -> new UserHandler(ErrorStatus.USER_NOT_FOUND));
 
         if (!request.password().equals(request.confirmPassword()))

--- a/src/main/java/com/company/newseat/auth/controller/AuthController.java
+++ b/src/main/java/com/company/newseat/auth/controller/AuthController.java
@@ -1,10 +1,7 @@
 package com.company.newseat.auth.controller;
 
 import com.company.newseat.auth.application.AuthService;
-import com.company.newseat.auth.dto.request.VerifyEmailCodeRequest ;
-import com.company.newseat.auth.dto.request.LoginRequest;
-import com.company.newseat.auth.dto.request.SendEmailCodeRequest;
-import com.company.newseat.auth.dto.request.SignUpRequest;
+import com.company.newseat.auth.dto.request.*;
 import com.company.newseat.auth.dto.response.*;
 import com.company.newseat.email.domain.EmailAuth;
 import com.company.newseat.global.response.ApiResponse;
@@ -74,7 +71,7 @@ public class AuthController {
         return authService.getTestToken(userId);
     }
 
-    @Operation(summary = "인증 이메일 전송", description = "인증 이메일 전송")
+    @Operation(summary = "인증 이메일 전송", description = "인증 이메일 전송 (Purpose 1 = 회원가입, Purpose 3 = 비밀번호 찾기)")
     @PostMapping("/email")
     public ResponseEntity<ApiResponse<SendEmailCodeResponse>> sendCodeMail(
             @RequestBody @Valid SendEmailCodeRequest request) {
@@ -94,5 +91,25 @@ public class AuthController {
         VerifyEmailCodeResponse response = VerifyEmailCodeResponse.of(isChecked);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "비밀번호 재설정 이메일 인증 확인", description = "비밀번호 재설정 전에 이메일 인증했는지 확인")
+    @PostMapping("/password-reset/verify")
+    public ResponseEntity<ApiResponse<PasswordResetVerifyResponse>> verifyPasswordReset(
+            @RequestBody @Valid PasswordResetVerifyRequest request) {
+
+        PasswordResetVerifyResponse response = authService.verifyPasswordReset(request);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "비밀번호 재설정", description = "로그인하지 않은 사용자의 비밀번호 재설정")
+    @PostMapping("/password-reset")
+    public ResponseEntity<ApiResponse<Void>> resetPassword(
+            @RequestBody @Valid ResetPasswordRequest request) {
+
+        authService.resetPassword(request);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
     }
 }

--- a/src/main/java/com/company/newseat/auth/dto/request/ChangePasswordRequest.java
+++ b/src/main/java/com/company/newseat/auth/dto/request/ChangePasswordRequest.java
@@ -4,8 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
-public record ResetPasswordRequest(
-
+public record ChangePasswordRequest(
         @NotBlank(message = "비밀번호는 필수 입력값입니다")
         @Size(min = 8, max = 16, message = "비밀번호를 8~16자 사이로 입력해주세요.")
         @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_+{}|:<>?~,-]{8,16}$",

--- a/src/main/java/com/company/newseat/auth/dto/request/PasswordResetVerifyRequest.java
+++ b/src/main/java/com/company/newseat/auth/dto/request/PasswordResetVerifyRequest.java
@@ -1,0 +1,9 @@
+package com.company.newseat.auth.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record PasswordResetVerifyRequest(
+        @NotNull(message = "emailAuthId 값이 없습니다.")
+        Long emailAuthId
+) {
+}

--- a/src/main/java/com/company/newseat/auth/dto/request/ResetPasswordRequest.java
+++ b/src/main/java/com/company/newseat/auth/dto/request/ResetPasswordRequest.java
@@ -1,0 +1,22 @@
+package com.company.newseat.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record ResetPasswordRequest (
+        @NotNull(message = "userId 값이 없습니다.")
+        Long userId,
+
+        @NotBlank(message = "비밀번호는 필수 입력값입니다")
+        @Size(min = 8, max = 16, message = "비밀번호를 8~16자 사이로 입력해주세요.")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_+{}|:<>?~,-]{8,16}$",
+                message = "비밀번호는 영문과 숫자를 반드시 포함해 8~16자로 입력해주세요.")
+        String password,
+
+        @NotBlank(message = "비밀번호 확인은 필수 입력값입니다")
+        @Size(min = 8, max = 16, message = "비밀번호를 8~16자 사이로 입력해주세요.")
+        String confirmPassword
+) {
+}

--- a/src/main/java/com/company/newseat/auth/dto/request/ResetPasswordRequest.java
+++ b/src/main/java/com/company/newseat/auth/dto/request/ResetPasswordRequest.java
@@ -1,0 +1,19 @@
+package com.company.newseat.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record ResetPasswordRequest(
+
+        @NotBlank(message = "비밀번호는 필수 입력값입니다")
+        @Size(min = 8, max = 16, message = "비밀번호를 8~16자 사이로 입력해주세요.")
+        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_+{}|:<>?~,-]{8,16}$",
+                message = "비밀번호는 영문과 숫자를 반드시 포함해 8~16자로 입력해주세요.")
+        String password,
+
+        @NotBlank(message = "비밀번호 확인은 필수 입력값입니다")
+        @Size(min = 8, max = 16, message = "비밀번호를 8~16자 사이로 입력해주세요.")
+        String confirmPassword
+) {
+}

--- a/src/main/java/com/company/newseat/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/company/newseat/auth/dto/request/SignUpRequest.java
@@ -20,7 +20,7 @@ public record SignUpRequest(
         String email,
 
         @NotBlank(message = "비밀번호는 필수 입력값입니다")
-        @Size(min = 8, max = 20, message = "비밀번호를 8~20자 사이로 입력해주세요.")
+        @Size(min = 8, max = 16, message = "비밀번호를 8~16자 사이로 입력해주세요.")
         @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d!@#$%^&*()_+{}|:<>?~,-]{8,16}$",
                 message = "비밀번호는 영문과 숫자를 반드시 포함해 8~16자로 입력해주세요.")
         String password,

--- a/src/main/java/com/company/newseat/auth/dto/response/PasswordResetVerifyResponse.java
+++ b/src/main/java/com/company/newseat/auth/dto/response/PasswordResetVerifyResponse.java
@@ -1,0 +1,9 @@
+package com.company.newseat.auth.dto.response;
+
+public record PasswordResetVerifyResponse(
+        Long userId
+) {
+    public static PasswordResetVerifyResponse of(Long userId) {
+        return new PasswordResetVerifyResponse(userId);
+    }
+}

--- a/src/main/java/com/company/newseat/email/repository/EmailAuthRepository.java
+++ b/src/main/java/com/company/newseat/email/repository/EmailAuthRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
     boolean existsByEmailAuthIdAndEmailAndPurposeAndIsChecked(Long emailAuthId, String email, Purpose purpose, BooleanType isChecked);
+
+    boolean existsByEmailAuthIdAndPurposeAndIsChecked(Long emailAuthId, Purpose purpose, BooleanType isChecked);
 }

--- a/src/main/java/com/company/newseat/global/exception/code/status/ErrorStatus.java
+++ b/src/main/java/com/company/newseat/global/exception/code/status/ErrorStatus.java
@@ -30,6 +30,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_AUTH_NOT_FOUND(NOT_FOUND, "AUTH4004", "이메일 인증 정보가 없습니다."),
     EMAIL_VERIFICATION_CODE_INVALID(BAD_REQUEST, "AUTH4005", "이메일 인증번호가 틀렸습니다."),
     EMAIL_VERIFICATION_EXPIRED(BAD_REQUEST, "AUTH4006", "이메일 인증 유효시간이 만료되었습니다."),
+    PASSWORD_NOT_CORRECT(BAD_REQUEST, "AUTH4007", "비밀번호 입력값과 일치하지 않습니다."),
 
     ACCESS_DENIED(FORBIDDEN, "AUTH4031", "접근 권한이 없습니다."),
 

--- a/src/main/java/com/company/newseat/user/domain/User.java
+++ b/src/main/java/com/company/newseat/user/domain/User.java
@@ -81,4 +81,8 @@ public class User {
     public void disableDetoxMode() {
         this.isDetox = false;
     }
+
+    public void changePassword(String password){
+        this.password = password;
+    }
 }

--- a/src/main/java/com/company/newseat/user/presentation/UserController.java
+++ b/src/main/java/com/company/newseat/user/presentation/UserController.java
@@ -1,7 +1,7 @@
 package com.company.newseat.user.presentation;
 
 import com.company.newseat.auth.application.AuthService;
-import com.company.newseat.auth.dto.request.ResetPasswordRequest;
+import com.company.newseat.auth.dto.request.ChangePasswordRequest;
 import com.company.newseat.global.response.ApiResponse;
 import com.company.newseat.user.dto.request.NewsModeRequest;
 import com.company.newseat.user.dto.response.NewsModeResponse;
@@ -88,7 +88,7 @@ public class UserController {
     @PatchMapping("/change-password")
     public ResponseEntity<ApiResponse<Void>> changePassword(
             @AuthenticationPrincipal Long userId,
-            @RequestBody @Valid ResetPasswordRequest request) {
+            @RequestBody @Valid ChangePasswordRequest request) {
 
         authService.changePassword(userId, request);
 

--- a/src/main/java/com/company/newseat/user/presentation/UserController.java
+++ b/src/main/java/com/company/newseat/user/presentation/UserController.java
@@ -1,5 +1,7 @@
 package com.company.newseat.user.presentation;
 
+import com.company.newseat.auth.application.AuthService;
+import com.company.newseat.auth.dto.request.ResetPasswordRequest;
 import com.company.newseat.global.response.ApiResponse;
 import com.company.newseat.user.dto.request.NewsModeRequest;
 import com.company.newseat.user.dto.response.NewsModeResponse;
@@ -25,6 +27,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserController {
 
     private final UserService userService;
+    private final AuthService authService;
 
     @Operation(summary = "마이페이지 프로필 조회", description = "마이페이지에서 닉네임 및 관심사 조회")
     @GetMapping("/profile")
@@ -72,12 +75,23 @@ public class UserController {
     }
 
     @Operation(summary = "내 정보 조회 (전역에서 사용)", description = "현재 로그인한 유저의 기본정보(닉네임) 조회")
-    @PutMapping("/me")
+    @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserSimpleInfoResponse>> getMyInfo(
             @AuthenticationPrincipal Long userId){
 
         UserSimpleInfoResponse response = userService.getMyInfo(userId);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "마이페이지 비밀번호 변경", description = "현재 로그인한 사용자의 비밀번호 변경")
+    @PatchMapping("/change-password")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody @Valid ResetPasswordRequest request) {
+
+        authService.changePassword(userId, request);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
     }
 }

--- a/src/main/java/com/company/newseat/user/presentation/UserController.java
+++ b/src/main/java/com/company/newseat/user/presentation/UserController.java
@@ -85,7 +85,7 @@ public class UserController {
     }
 
     @Operation(summary = "마이페이지 비밀번호 변경", description = "현재 로그인한 사용자의 비밀번호 변경")
-    @PatchMapping("/change-password")
+    @PatchMapping("/password")
     public ResponseEntity<ApiResponse<Void>> changePassword(
             @AuthenticationPrincipal Long userId,
             @RequestBody @Valid ChangePasswordRequest request) {


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #37 


## ✏️ 작업 내용

- 비밀번호 수정 기능 (로그인한 사용자)
- 비밀번호 재설정 기능 (비밀번호 찾기) (로그인 하지 않은 사용자)
  - 이메일 인증 (Purpose 3) -> 이메일 코드 확인 -> 이메일 인증 확인 (emailAuthId 값) -> 비밀번호 재설정


## ✅ 체크리스트
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
