### PR TITLE
[FIX] 뉴스 제목 HTML 엔티티 디코딩 처리

### DIFF
--- a/src/main/java/com/company/newseat/bookmark/dto/response/BookmarkResponse.java
+++ b/src/main/java/com/company/newseat/bookmark/dto/response/BookmarkResponse.java
@@ -3,6 +3,7 @@ package com.company.newseat.bookmark.dto.response;
 import com.company.newseat.bookmark.domain.Bookmark;
 import com.company.newseat.global.util.DateUtil;
 import com.company.newseat.news.domain.type.Sentiment;
+import org.springframework.web.util.HtmlUtils;
 
 import java.util.Optional;
 
@@ -29,8 +30,8 @@ public record BookmarkResponse(
 
         return new BookmarkResponse(
                 bookmark.getBookmarkId(),
-                bookmark.getTitle(),
-                bookmark.getContent(),
+                HtmlUtils.htmlUnescape(bookmark.getTitle()),
+                HtmlUtils.htmlUnescape(bookmark.getContent()),
                 bookmark.getPublisher(),
                 sentiment,
                 formattedPublishedAt,

--- a/src/main/java/com/company/newseat/bookmark/dto/response/BookmarkSimpleResponse.java
+++ b/src/main/java/com/company/newseat/bookmark/dto/response/BookmarkSimpleResponse.java
@@ -2,6 +2,7 @@ package com.company.newseat.bookmark.dto.response;
 
 import com.company.newseat.bookmark.domain.Bookmark;
 import com.company.newseat.global.util.DateUtil;
+import org.springframework.web.util.HtmlUtils;
 
 public record BookmarkSimpleResponse(
         Long bookmarkId,
@@ -16,7 +17,7 @@ public record BookmarkSimpleResponse(
 
         return new BookmarkSimpleResponse(
                 bookmark.getBookmarkId(),
-                bookmark.getTitle(),
+                HtmlUtils.htmlUnescape(bookmark.getTitle()),
                 bookmark.getCategory(),
                 bookmark.getImgUrl(),
                 formattedPublishedAt,

--- a/src/main/java/com/company/newseat/bookmark/dto/response/BookmarkSummaryResponse.java
+++ b/src/main/java/com/company/newseat/bookmark/dto/response/BookmarkSummaryResponse.java
@@ -1,11 +1,17 @@
 package com.company.newseat.bookmark.dto.response;
 
+import org.springframework.web.util.HtmlUtils;
+
 public record BookmarkSummaryResponse(
         String title,
         String sentiment,
         String summaryResult
 ) {
     public static BookmarkSummaryResponse of (String title, String sentiment, String summaryResult) {
-        return new BookmarkSummaryResponse(title, sentiment, summaryResult);
+        return new BookmarkSummaryResponse(
+                HtmlUtils.htmlUnescape(title),
+                sentiment,
+                summaryResult
+        );
     }
 }

--- a/src/main/java/com/company/newseat/news/dto/response/CategoryNewsResponse.java
+++ b/src/main/java/com/company/newseat/news/dto/response/CategoryNewsResponse.java
@@ -2,6 +2,7 @@ package com.company.newseat.news.dto.response;
 
 import com.company.newseat.global.util.DateUtil;
 import com.company.newseat.news.domain.News;
+import org.springframework.web.util.HtmlUtils;
 
 public record CategoryNewsResponse(
         Long newsId,
@@ -15,7 +16,7 @@ public record CategoryNewsResponse(
 
         return new CategoryNewsResponse(
                 news.getNewsId(),
-                news.getTitle(),
+                HtmlUtils.htmlUnescape(news.getTitle()),
                 news.getImgUrl(),
                 news.getPublisher(),
                 formattedPublishedAt

--- a/src/main/java/com/company/newseat/news/dto/response/NewsDetailResponse.java
+++ b/src/main/java/com/company/newseat/news/dto/response/NewsDetailResponse.java
@@ -4,6 +4,7 @@ import com.company.newseat.category.domain.Category;
 import com.company.newseat.global.util.DateUtil;
 import com.company.newseat.news.domain.News;
 import com.company.newseat.news.domain.type.Sentiment;
+import org.springframework.web.util.HtmlUtils;
 
 import java.util.Optional;
 
@@ -34,8 +35,8 @@ public record NewsDetailResponse(
 
         return new NewsDetailResponse(
                 news.getNewsId(),
-                news.getTitle(),
-                news.getContent(),
+                HtmlUtils.htmlUnescape(news.getTitle()),
+                HtmlUtils.htmlUnescape(news.getContent()),
                 news.getImgUrl(),
                 news.getPublisher(),
                 formattedPublishedAt,

--- a/src/main/java/com/company/newseat/news/dto/response/NewsItemResponse.java
+++ b/src/main/java/com/company/newseat/news/dto/response/NewsItemResponse.java
@@ -1,6 +1,7 @@
 package com.company.newseat.news.dto.response;
 
 import com.company.newseat.news.domain.News;
+import org.springframework.web.util.HtmlUtils;
 
 public record NewsItemResponse (
         Long newsId,
@@ -11,7 +12,7 @@ public record NewsItemResponse (
         return new NewsItemResponse(
                 news.getNewsId(),
                 news.getImgUrl(),
-                news.getTitle()
+                HtmlUtils.htmlUnescape(news.getTitle())
         );
     }
 }

--- a/src/main/java/com/company/newseat/news/dto/response/NewsSummaryResponse.java
+++ b/src/main/java/com/company/newseat/news/dto/response/NewsSummaryResponse.java
@@ -1,11 +1,17 @@
 package com.company.newseat.news.dto.response;
 
+import org.springframework.web.util.HtmlUtils;
+
 public record NewsSummaryResponse (
         String title,
         String sentiment,
         String summaryResult
 ) {
     public static NewsSummaryResponse of (String title, String sentiment, String summaryResult) {
-        return new NewsSummaryResponse(title, sentiment, summaryResult);
+        return new NewsSummaryResponse(
+                HtmlUtils.htmlUnescape(title),
+                sentiment,
+                summaryResult
+        );
     }
 }

--- a/src/main/java/com/company/newseat/news/dto/response/SearchNewsResponse.java
+++ b/src/main/java/com/company/newseat/news/dto/response/SearchNewsResponse.java
@@ -2,6 +2,7 @@ package com.company.newseat.news.dto.response;
 
 import com.company.newseat.global.util.DateUtil;
 import com.company.newseat.news.domain.News;
+import org.springframework.web.util.HtmlUtils;
 
 public record SearchNewsResponse(
         Long newsId,
@@ -16,7 +17,7 @@ public record SearchNewsResponse(
                 news.getNewsId(),
                 news.getImgUrl(),
                 news.getPublisher(),
-                news.getTitle(),
+                HtmlUtils.htmlUnescape(news.getTitle()),
                 formattedPublishedAt
         );
     }


### PR DESCRIPTION
## 🛠 관련 이슈

- Resolves #43 


## ✏️ 작업 내용

- 뉴스 제목에서 HTML &amp; 와 같이 노출되던 문제 디코딩 처리로 수정


## ✅ 체크리스트
- [x] PR 제목을 커밋 규칙에 맞게 작성
- [x] PR에 해당되는 Issue를 연결 완료
- [x] 작업한 사람 모두를 Assign
- [x] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x] `main` 브랜치의 최신 상태를 반영하고 있는지 확인

